### PR TITLE
upgraded nodatime to v2.0, still some tests are failing

### DIFF
--- a/Raven.Bundles.NodaTime/Indexing/NodaTimeField.cs
+++ b/Raven.Bundles.NodaTime/Indexing/NodaTimeField.cs
@@ -24,7 +24,7 @@ namespace Raven.Bundles.NodaTime.Indexing
 
         public static LocalDate AsLocalDate(string value)
         {
-            return LocalDatePattern.IsoPattern.Parse(value).Value;
+            return LocalDatePattern.Iso.Parse(value).Value;
         }
 
         public static LocalTime AsLocalTime(TimeSpan value)
@@ -78,7 +78,7 @@ namespace Raven.Bundles.NodaTime.Indexing
 
         public static string Resolve(LocalDate value)
         {
-            return value.ToString(LocalDatePattern.IsoPattern.PatternText, null);
+            return value.ToString(LocalDatePattern.Iso.PatternText, null);
         }
 
         public static TimeSpan Resolve(LocalTime value)

--- a/Raven.Bundles.NodaTime/Raven.Bundles.NodaTime.csproj
+++ b/Raven.Bundles.NodaTime/Raven.Bundles.NodaTime.csproj
@@ -35,9 +35,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
+    <Reference Include="NodaTime, Version=2.0.3.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NodaTime.2.0.3\lib\net45\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="Raven.Abstractions, Version=3.5.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\packages\RavenDB.Database.3.5.0\lib\net45\Raven.Abstractions.dll</HintPath>

--- a/Raven.Bundles.NodaTime/packages.config
+++ b/Raven.Bundles.NodaTime/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NodaTime" version="1.3.0" targetFramework="net45" />
+  <package id="NodaTime" version="2.0.3" targetFramework="net45" />
   <package id="RavenDB.Client" version="3.5.0" targetFramework="net45" />
   <package id="RavenDB.Database" version="3.5.0" targetFramework="net45" />
 </packages>

--- a/Raven.Client.NodaTime.Tests/ComplexTest.cs
+++ b/Raven.Client.NodaTime.Tests/ComplexTest.cs
@@ -255,7 +255,7 @@ namespace Raven.Client.NodaTime.Tests
                     let daysInPeriod = fromDate.DaysBetween(toDate)
                     from day in Enumerable.Range(0, daysInPeriod)
                     let date = fromDate.PlusDays(day)
-                    let hours = schedule.BusinessHours.FirstOrDefault(x => x.DayOfWeek.ToString() == date.IsoDayOfWeek.ToString())
+                    let hours = schedule.BusinessHours.FirstOrDefault(x => x.DayOfWeek.ToString() == date.DayOfWeek.ToString())
                     let localOpen = date + hours.Open.AsLocalTime()
                     let localClose = date.PlusDays(hours.Close > hours.Open ? 0 : 1) + hours.Close.AsLocalTime()
                     select new

--- a/Raven.Client.NodaTime.Tests/DictionaryKeyConverterTests.cs
+++ b/Raven.Client.NodaTime.Tests/DictionaryKeyConverterTests.cs
@@ -14,7 +14,7 @@ namespace Raven.Client.NodaTime.Tests
             {
                 documentStore.ConfigureForNodaTime();
 
-                Instant i1 = SystemClock.Instance.Now;
+                Instant i1 = SystemClock.Instance.GetCurrentInstant();
                 Instant i2 = i1 + Duration.FromHours(1);
 
                 using (var session = documentStore.OpenSession())
@@ -41,7 +41,7 @@ namespace Raven.Client.NodaTime.Tests
             {
                 documentStore.ConfigureForNodaTime();
 
-                Instant i1 = SystemClock.Instance.Now;
+                Instant i1 = SystemClock.Instance.GetCurrentInstant();
                 Instant i2 = i1 + Duration.FromHours(1);
 
                 using (var session = documentStore.OpenSession())

--- a/Raven.Client.NodaTime.Tests/NodaInstantTests.cs
+++ b/Raven.Client.NodaTime.Tests/NodaInstantTests.cs
@@ -22,7 +22,7 @@ namespace Raven.Client.NodaTime.Tests
         [Fact]
         public void Can_Use_NodaTime_Instant_In_Document_Now()
         {
-            Can_Use_NodaTime_Instant_In_Document(SystemClock.Instance.Now);
+            Can_Use_NodaTime_Instant_In_Document(SystemClock.Instance.GetCurrentInstant());
         }
 
         [Fact]
@@ -78,7 +78,7 @@ namespace Raven.Client.NodaTime.Tests
         [Fact]
         public void Can_Use_NodaTime_Instant_In_Dynamic_Index_Now()
         {
-            Can_Use_NodaTime_Instant_In_Dynamic_Index1(SystemClock.Instance.Now);
+            Can_Use_NodaTime_Instant_In_Dynamic_Index1(SystemClock.Instance.GetCurrentInstant());
         }
 
         [Fact]
@@ -186,7 +186,7 @@ namespace Raven.Client.NodaTime.Tests
         [Fact]
         public void Can_Use_NodaTime_Instant_In_Static_Index_Now()
         {
-            Can_Use_NodaTime_Instant_In_Static_Index1(SystemClock.Instance.Now);
+            Can_Use_NodaTime_Instant_In_Static_Index1(SystemClock.Instance.GetCurrentInstant());
         }
 
         [Fact]

--- a/Raven.Client.NodaTime.Tests/NodaInstantTests.cs
+++ b/Raven.Client.NodaTime.Tests/NodaInstantTests.cs
@@ -44,9 +44,9 @@ namespace Raven.Client.NodaTime.Tests
         }
 
         [Fact]
-        public void Cannot_Use_NodaTime_Instant_In_Document_When_Too_Large()
+        public void Can_Use_NodaTime_Instant_In_Document_Instant_MaxValue()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Can_Use_NodaTime_Instant_In_Document(Instant.MaxValue));
+            Can_Use_NodaTime_Instant_In_Document(Instant.MaxValue);
         }
 
         private void Can_Use_NodaTime_Instant_In_Document(Instant instant)
@@ -65,7 +65,7 @@ namespace Raven.Client.NodaTime.Tests
                 {
                     var foo = session.Load<Foo>("foos/1");
 
-                    Assert.Equal(instant, foo.Instant);
+                    Assert.Equal(instant.ToUnixTimeTicks(), foo.Instant.ToUnixTimeTicks());
                 }
 
                 var json = documentStore.DatabaseCommands.Get("foos/1").DataAsJson;
@@ -100,9 +100,9 @@ namespace Raven.Client.NodaTime.Tests
         }
 
         [Fact]
-        public void Cannot_Use_NodaTime_Instant_In_Dynamic_Index_When_Too_Large()
+        public void Can_Use_NodaTime_Instant_In_Dynamic_Index_MaxValue()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Can_Use_NodaTime_Instant_In_Dynamic_Index2(Instant.MaxValue));
+            Can_Use_NodaTime_Instant_In_Dynamic_Index2(Instant.MaxValue);
         }
 
         private void Can_Use_NodaTime_Instant_In_Dynamic_Index1(Instant instant)
@@ -208,9 +208,9 @@ namespace Raven.Client.NodaTime.Tests
         }
 
         [Fact]
-        public void Cannot_Use_NodaTime_Instant_In_Static_Index_When_Too_Large()
+        public void Can_Use_NodaTime_Instant_In_Static_Index_MaxValue()
         {
-            Assert.Throws<ArgumentOutOfRangeException>(() => Can_Use_NodaTime_Instant_In_Static_Index2(Instant.MaxValue));
+            Can_Use_NodaTime_Instant_In_Static_Index2(Instant.MaxValue);
         }
 
         private void Can_Use_NodaTime_Instant_In_Static_Index1(Instant instant)

--- a/Raven.Client.NodaTime.Tests/NodaIntervalTests.cs
+++ b/Raven.Client.NodaTime.Tests/NodaIntervalTests.cs
@@ -13,7 +13,7 @@ namespace Raven.Client.NodaTime.Tests
         [Fact]
         public void Can_Use_NodaTime_Interval_In_Document()
         {
-            var now = SystemClock.Instance.Now;
+            var now = SystemClock.Instance.GetCurrentInstant();
             var start = now - Duration.FromMinutes(5);
             var end = now + Duration.FromMinutes(5);
             var interval = new Interval(start, end);
@@ -47,7 +47,7 @@ namespace Raven.Client.NodaTime.Tests
         [Fact]
         public void Can_Use_NodaTime_Interval_In_Dynamic_Index()
         {
-            var now = SystemClock.Instance.Now;
+            var now = SystemClock.Instance.GetCurrentInstant();
             var start = now - Duration.FromMinutes(5);
             var end = now + Duration.FromMinutes(5);
             var interval1 = new Interval(start, end);
@@ -91,7 +91,7 @@ namespace Raven.Client.NodaTime.Tests
         [Fact]
         public void Can_Use_NodaTime_Interval_In_Static_Index()
         {
-            var now = SystemClock.Instance.Now;
+            var now = SystemClock.Instance.GetCurrentInstant();
             var start = now - Duration.FromMinutes(5);
             var end = now + Duration.FromMinutes(5);
             var interval1 = new Interval(start, end);

--- a/Raven.Client.NodaTime.Tests/NodaLocalDateTests.cs
+++ b/Raven.Client.NodaTime.Tests/NodaLocalDateTests.cs
@@ -50,7 +50,7 @@ namespace Raven.Client.NodaTime.Tests
 
                 var json = documentStore.DatabaseCommands.Get("foos/1").DataAsJson;
                 Debug.WriteLine(json.ToString(Formatting.Indented));
-                var expected = ld.ToString(LocalDatePattern.IsoPattern.PatternText, null);
+                var expected = ld.ToString(LocalDatePattern.Iso.PatternText, null);
                 Assert.Equal(expected, json.Value<string>("LocalDate"));
             }
         }

--- a/Raven.Client.NodaTime.Tests/NodaZonedDateTimeTests.cs
+++ b/Raven.Client.NodaTime.Tests/NodaZonedDateTimeTests.cs
@@ -26,7 +26,7 @@ namespace Raven.Client.NodaTime.Tests
         [Fact]
         public void Can_Use_NodaTime_ZonedDateTime_In_Document_Now()
         {
-            var instant = SystemClock.Instance.Now;
+            var instant = SystemClock.Instance.GetCurrentInstant();
             var zone = DateTimeZoneProviders.Tzdb.GetSystemDefault();
             var zdt = new ZonedDateTime(instant, zone);
             Can_Use_NodaTime_ZonedDateTime_In_Document(zdt);
@@ -73,7 +73,7 @@ namespace Raven.Client.NodaTime.Tests
         [Fact]
         public void Can_Use_NodaTime_ZonedDateTime_In_Dynamic_Index_Now()
         {
-            var instant = SystemClock.Instance.Now;
+            var instant = SystemClock.Instance.GetCurrentInstant();
             var zone = DateTimeZoneProviders.Tzdb.GetSystemDefault();
             Can_Use_NodaTime_ZonedDateTime_In_Dynamic_Index(new ZonedDateTime(instant, zone));
         }
@@ -118,15 +118,15 @@ namespace Raven.Client.NodaTime.Tests
                                     .OrderBy(x => x.ZonedDateTime.ToInstant());
                     var results2 = q2.ToList();
                     Assert.Equal(2, results2.Count);
-                    Assert.True(results2[0].ZonedDateTime < results2[1].ZonedDateTime);
+                    Assert.True(ZonedDateTime.Comparer.Local.Compare(results2[0].ZonedDateTime, results2[1].ZonedDateTime) < 0);
 
                     var q3 = session.Query<Foo>().Customize(x => x.WaitForNonStaleResults())
                                     .Where(x => x.ZonedDateTime.ToInstant() <= zdt.ToInstant())
                                     .OrderBy(x => x.ZonedDateTime.ToInstant());
                     var results3 = q3.ToList();
                     Assert.Equal(3, results3.Count);
-                    Assert.True(results3[0].ZonedDateTime < results3[1].ZonedDateTime);
-                    Assert.True(results3[1].ZonedDateTime < results3[2].ZonedDateTime);
+                    Assert.True(ZonedDateTime.Comparer.Local.Compare(results3[0].ZonedDateTime, results3[1].ZonedDateTime) < 0);
+                    Assert.True(ZonedDateTime.Comparer.Local.Compare(results3[1].ZonedDateTime, results3[2].ZonedDateTime) < 0);
                 }
             }
         }
@@ -134,7 +134,7 @@ namespace Raven.Client.NodaTime.Tests
         [Fact]
         public void Can_Use_NodaTime_ZonedDateTime_In_Static_Index_Now()
         {
-            var instant = SystemClock.Instance.Now;
+            var instant = SystemClock.Instance.GetCurrentInstant();
             var zone = DateTimeZoneProviders.Tzdb.GetSystemDefault();
             Can_Use_NodaTime_ZonedDateTime_In_Static_Index(new ZonedDateTime(instant, zone));
         }
@@ -170,19 +170,19 @@ namespace Raven.Client.NodaTime.Tests
                     Assert.Equal(1, results1.Count);
 
                     var q2 = session.Query<Foo, TestIndex>().Customize(x => x.WaitForNonStaleResults())
-                                    .Where(x => x.ZonedDateTime < zdt)
+                                    .Where(x => ZonedDateTime.Comparer.Local.Compare(x.ZonedDateTime, zdt) < 0)
                                     .OrderBy(x => x.ZonedDateTime);
                     var results2 = q2.ToList();
                     Assert.Equal(2, results2.Count);
-                    Assert.True(results2[0].ZonedDateTime < results2[1].ZonedDateTime);
+                    Assert.True(ZonedDateTime.Comparer.Local.Compare(results2[0].ZonedDateTime, results2[1].ZonedDateTime) < 0);
 
                     var q3 = session.Query<Foo, TestIndex>().Customize(x => x.WaitForNonStaleResults())
-                                    .Where(x => x.ZonedDateTime <= zdt)
+                                    .Where(x => ZonedDateTime.Comparer.Local.Compare(x.ZonedDateTime, zdt) <= 0)
                                     .OrderBy(x => x.ZonedDateTime);
                     var results3 = q3.ToList();
                     Assert.Equal(3, results3.Count);
-                    Assert.True(results3[0].ZonedDateTime < results3[1].ZonedDateTime);
-                    Assert.True(results3[1].ZonedDateTime < results3[2].ZonedDateTime);
+                    Assert.True(ZonedDateTime.Comparer.Local.Compare(results3[0].ZonedDateTime, results3[1].ZonedDateTime) < 0);
+                    Assert.True(ZonedDateTime.Comparer.Local.Compare(results3[1].ZonedDateTime, results3[2].ZonedDateTime) < 0);
                 }
             }
         }
@@ -190,7 +190,7 @@ namespace Raven.Client.NodaTime.Tests
         [Fact]
         public void Can_Use_NodaTime_ZonedDateTime_In_Static_MapReduceIndex()
         {
-            var zdt = SystemClock.Instance.Now.InZone(DateTimeZoneProviders.Tzdb.GetSystemDefault());
+            var zdt = SystemClock.Instance.GetCurrentInstant().InZone(DateTimeZoneProviders.Tzdb.GetSystemDefault());
 
             using (var documentStore = NewDocumentStore())
             {

--- a/Raven.Client.NodaTime.Tests/Raven.Client.NodaTime.Tests.csproj
+++ b/Raven.Client.NodaTime.Tests/Raven.Client.NodaTime.Tests.csproj
@@ -35,9 +35,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
+    <Reference Include="NodaTime, Version=2.0.3.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NodaTime.2.0.3\lib\net45\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="Raven.Abstractions, Version=3.5.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\packages\RavenDB.Tests.Helpers.3.5.0\lib\net45\Raven.Abstractions.dll</HintPath>

--- a/Raven.Client.NodaTime.Tests/TimeZoneConversionTests/DateTimeZoneTests_Bcl.cs
+++ b/Raven.Client.NodaTime.Tests/TimeZoneConversionTests/DateTimeZoneTests_Bcl.cs
@@ -28,7 +28,7 @@ namespace Raven.Client.NodaTime.Tests.TimeZoneConversionTests
 
                 using (var session = documentStore.OpenSession())
                 {
-                    session.Store(new Foo { Instant = SystemClock.Instance.Now });
+                    session.Store(new Foo { Instant = SystemClock.Instance.GetCurrentInstant() });
                     session.SaveChanges();
                 }
 

--- a/Raven.Client.NodaTime.Tests/TimeZoneConversionTests/DateTimeZoneTests_Tzdb.cs
+++ b/Raven.Client.NodaTime.Tests/TimeZoneConversionTests/DateTimeZoneTests_Tzdb.cs
@@ -28,7 +28,7 @@ namespace Raven.Client.NodaTime.Tests.TimeZoneConversionTests
 
                 using (var session = documentStore.OpenSession())
                 {
-                    session.Store(new Foo { Instant = SystemClock.Instance.Now });
+                    session.Store(new Foo { Instant = SystemClock.Instance.GetCurrentInstant() });
                     session.SaveChanges();
                 }
 

--- a/Raven.Client.NodaTime.Tests/packages.config
+++ b/Raven.Client.NodaTime.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NodaTime" version="1.3.0" targetFramework="net45" />
+  <package id="NodaTime" version="2.0.3" targetFramework="net45" />
   <package id="RavenDB.Client" version="3.5.0" targetFramework="net45" />
   <package id="RavenDB.Database" version="3.5.0" targetFramework="net45" />
   <package id="RavenDB.Tests.Helpers" version="3.5.0" targetFramework="net45" />

--- a/Raven.Client.NodaTime/CustomQueryValueConverters.cs
+++ b/Raven.Client.NodaTime/CustomQueryValueConverters.cs
@@ -25,7 +25,7 @@ namespace Raven.Client.NodaTime
 
         public static bool LocalDateConverter(string name, LocalDate value, QueryValueConvertionType type, out string strValue)
         {
-            strValue = value.ToString(LocalDatePattern.IsoPattern.PatternText, null);
+            strValue = value.ToString(LocalDatePattern.Iso.PatternText, null);
 
             return true;
         }
@@ -67,7 +67,7 @@ namespace Raven.Client.NodaTime
         {
             if (type == QueryValueConvertionType.Range)
             {
-                strValue = NumberUtil.NumberToString(value.Ticks);
+                strValue = NumberUtil.NumberToString(value.BclCompatibleTicks);
 
                 return true;
             }

--- a/Raven.Client.NodaTime/Imports/NodaTime.Serialization.JsonNet/NodaConverters.cs
+++ b/Raven.Client.NodaTime/Imports/NodaTime.Serialization.JsonNet/NodaConverters.cs
@@ -18,26 +18,26 @@ namespace Raven.Imports.NodaTime.Serialization.JsonNet
         /// Converter for instants, using the ISO-8601 date/time pattern, extended as required to accommodate milliseconds and ticks, and
         /// specifying 'Z' at the end to show it's effectively in UTC.
         /// </summary>
-        public static readonly JsonConverter InstantConverter = new NodaPatternConverter<Instant>(InstantPattern.ExtendedIsoPattern);
+        public static readonly JsonConverter InstantConverter = new NodaPatternConverter<Instant>(InstantPattern.ExtendedIso);
 
         /// <summary>
         /// Converter for local dates, using the ISO-8601 date pattern.
         /// </summary>
         // TODO(Post-V1): Consider improving the behaviour with non-ISO calendars. We probably want a pattern which "knows" about a particular calendar, and restricts itself to that calendar.
         public static readonly JsonConverter LocalDateConverter = new NodaPatternConverter<LocalDate>(
-            LocalDatePattern.IsoPattern, CreateIsoValidator<LocalDate>(x => x.Calendar));
+            LocalDatePattern.Iso, CreateIsoValidator<LocalDate>(x => x.Calendar));
 
         /// <summary>
         /// Converter for local dates and times, using the ISO-8601 date/time pattern, extended as required to accommodate milliseconds and ticks.
         /// No time zone designator is applied.
         /// </summary>
         public static readonly JsonConverter LocalDateTimeConverter = new NodaPatternConverter<LocalDateTime>(
-            LocalDateTimePattern.ExtendedIsoPattern, CreateIsoValidator<LocalDateTime>(x => x.Calendar));
+            LocalDateTimePattern.ExtendedIso, CreateIsoValidator<LocalDateTime>(x => x.Calendar));
 
         /// <summary>
         /// Converter for local times, using the ISO-8601 time pattern, extended as required to accommodate milliseconds and ticks.
         /// </summary>
-        public static readonly JsonConverter LocalTimeConverter = new NodaPatternConverter<LocalTime>(LocalTimePattern.ExtendedIsoPattern);
+        public static readonly JsonConverter LocalTimeConverter = new NodaPatternConverter<LocalTime>(LocalTimePattern.ExtendedIso);
 
         /// <summary>
         /// Converter for intervals. This must be used in a serializer which also has an instant converter.
@@ -47,7 +47,7 @@ namespace Raven.Imports.NodaTime.Serialization.JsonNet
         /// <summary>
         /// Converter for offsets.
         /// </summary>
-        public static readonly JsonConverter OffsetConverter = new NodaPatternConverter<Offset>(OffsetPattern.GeneralInvariantPattern);
+        public static readonly JsonConverter OffsetConverter = new NodaPatternConverter<Offset>(OffsetPattern.GeneralInvariant);
 
         /// <summary>
         /// Converter for durations.
@@ -58,14 +58,14 @@ namespace Raven.Imports.NodaTime.Serialization.JsonNet
         /// Round-tripping converter for periods. Use this when you really want to preserve information,
         /// and don't need interoperability with systems expecting ISO.
         /// </summary>
-        public static readonly JsonConverter RoundtripPeriodConverter = new NodaPatternConverter<Period>(PeriodPattern.RoundtripPattern);
+        public static readonly JsonConverter RoundtripPeriodConverter = new NodaPatternConverter<Period>(PeriodPattern.Roundtrip);
 
         /// <summary>
         /// Normalizing ISO converter for periods. Use this when you want compatibility with systems expecting
         /// ISO durations (~= Noda Time periods). However, note that Noda Time can have negative periods. Note that
         /// this converter losees information - after serialization and deserialization, "90 minutes" will become "an hour and 30 minutes".
         /// </summary>
-        public static readonly JsonConverter NormalizingIsoPeriodConverter = new NodaPatternConverter<Period>(PeriodPattern.NormalizingIsoPattern);
+        public static readonly JsonConverter NormalizingIsoPeriodConverter = new NodaPatternConverter<Period>(PeriodPattern.NormalizingIso);
 
         /// <summary>
         /// Converter for using instants as dictionary keys.

--- a/Raven.Client.NodaTime/Imports/NodaTime.Serialization.JsonNet/NodaDurationConverter.cs
+++ b/Raven.Client.NodaTime/Imports/NodaTime.Serialization.JsonNet/NodaDurationConverter.cs
@@ -75,11 +75,12 @@ namespace Raven.Imports.NodaTime.Serialization.JsonNet
         /// <param name="serializer">Unused by this serializer</param>
         protected override void WriteJsonImpl(JsonWriter writer, Duration value, JsonSerializer serializer)
         {
-            var hours = value.Ticks / NodaConstants.TicksPerHour;
-            var minutes = (value.Ticks % NodaConstants.TicksPerHour) / NodaConstants.TicksPerMinute;
-            var seconds = (value.Ticks % NodaConstants.TicksPerMinute) / NodaConstants.TicksPerSecond;
-            var milliseconds = (value.Ticks % NodaConstants.TicksPerSecond) / NodaConstants.TicksPerMillisecond;
-            var ticks = value.Ticks % NodaConstants.TicksPerMillisecond;
+            var bclTicks = value.BclCompatibleTicks;
+            var hours = bclTicks / NodaConstants.TicksPerHour;
+            var minutes = (bclTicks % NodaConstants.TicksPerHour) / NodaConstants.TicksPerMinute;
+            var seconds = (bclTicks % NodaConstants.TicksPerMinute) / NodaConstants.TicksPerSecond;
+            var milliseconds = (bclTicks % NodaConstants.TicksPerSecond) / NodaConstants.TicksPerMillisecond;
+            var ticks = bclTicks % NodaConstants.TicksPerMillisecond;
 
             var durationText = string.Format("{0:D2}:{1:D2}:{2:D2}", hours, minutes, seconds);
 

--- a/Raven.Client.NodaTime/NodaUtil.cs
+++ b/Raven.Client.NodaTime/NodaUtil.cs
@@ -14,17 +14,17 @@ namespace Raven.Client.NodaTime
 
             public static global::NodaTime.Instant MinIsoValue
             {
-                get { return new global::NodaTime.Instant(MinIsoTicks); }
+                get { return global::NodaTime.Instant.FromUnixTimeTicks(MinIsoTicks); }
             }
 
             public static global::NodaTime.Instant MaxIsoValue
             {
-                get { return new global::NodaTime.Instant(MaxIsoTicks); }
+                get { return global::NodaTime.Instant.FromUnixTimeTicks(MaxIsoTicks); }
             }
 
             internal static void Validate(global::NodaTime.Instant instant)
             {
-                if (instant.Ticks >= MinIsoTicks && instant.Ticks <= MaxIsoTicks)
+                if (instant.ToUnixTimeTicks() >= MinIsoTicks && instant.ToUnixTimeTicks() <= MaxIsoTicks)
                     return;
 
                 var message = "NodaTime Instant values must fall between UTC years 0001 and 9999 to be compatible with RavenDB.";
@@ -113,7 +113,7 @@ namespace Raven.Client.NodaTime
 
             public static global::NodaTime.LocalTime MaxIsoValue
             {
-                get { return new global::NodaTime.LocalTime(23, 59, 59, 999, 9999); }
+                get { return global::NodaTime.LocalTime.FromHourMinuteSecondMillisecondTick(23, 59, 59, 999, 9999); }
             }
 
             public static global::NodaTime.LocalTime Now

--- a/Raven.Client.NodaTime/Raven.Client.NodaTime.csproj
+++ b/Raven.Client.NodaTime/Raven.Client.NodaTime.csproj
@@ -38,9 +38,8 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="NodaTime, Version=1.3.0.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\packages\NodaTime.1.3.0\lib\net35-Client\NodaTime.dll</HintPath>
+    <Reference Include="NodaTime, Version=2.0.3.0, Culture=neutral, PublicKeyToken=4226afe0d9b296d1, processorArchitecture=MSIL">
+      <HintPath>..\packages\NodaTime.2.0.3\lib\net45\NodaTime.dll</HintPath>
     </Reference>
     <Reference Include="Raven.Abstractions, Version=3.5.0.0, Culture=neutral, PublicKeyToken=37f41c7f99471593, processorArchitecture=MSIL">
       <HintPath>..\packages\RavenDB.Client.3.5.0\lib\net45\Raven.Abstractions.dll</HintPath>

--- a/Raven.Client.NodaTime/packages.config
+++ b/Raven.Client.NodaTime/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NodaTime" version="1.3.0" targetFramework="net45" />
+  <package id="NodaTime" version="2.0.3" targetFramework="net45" />
   <package id="RavenDB.Client" version="3.5.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
#12 upgraded to nodatime v2.0 but some tests are failing:

- Cannot_Use_NodaTime_Instant_In_Document_When_Too_Large
- Cannot_Use_NodaTime_Instant_In_Dynamic_Index_When_Too_Large
- Cannot_Use_NodaTime_Instant_In_Static_Index_When_Too_Large
Not sure what is happening here since the max value seems to be a valid Instant (now).
Do we need another max value?

- Can_Use_NodaTime_ZonedDateTime_In_Static_Index_NearIsoMax
- Can_Use_NodaTime_ZonedDateTime_In_Static_Index_Now
Not sure if we can fix this as NodaTime v2.0 has replaced the comparison operators with a comparer, but this comparer can obviously not be used on the ravendb server ...